### PR TITLE
Updating CLI to 2.5.553

### DIFF
--- a/cli-feed-v3.json
+++ b/cli-feed-v3.json
@@ -17,7 +17,7 @@
       "hidden": true
     },
     "v2": {
-      "release": "2.18.4",
+      "release": "2.18.5",
       "displayName": "Azure Functions v2 (.NET Core)",
       "displayVersion": "v2",
       "releaseQuality": "GA",
@@ -1030,8 +1030,8 @@
         },
         "2.18.5": {
           "Microsoft.NET.Sdk.Functions": "1.0.26",
-          "cli": "https://functionscdn.azureedge.net/public/2.5.539/Azure.Functions.Cli.min.win-x86.2.5.539.zip",
-          "sha2": "D96AAD69C024845645EFAD3D154753A9110D1F1B7294343FDC66570826ECE1A6",
+          "cli": "https://functionscdn.azureedge.net/public/2.5.553/Azure.Functions.Cli.min.win-x86.2.5.553.zip",
+          "sha2": "F8D4EC48A8CC1167227DE433864209CF2960CD3BB12DC1B5037758D4E1630D2F",
           "nodeVersion": "8.11.1",
           "localEntryPoint": "func.exe",
           "itemTemplates": "https://www.nuget.org/api/v2/package/Microsoft.Azure.WebJobs.ItemTemplates/2.0.10344",
@@ -1044,26 +1044,26 @@
               {
                   "OS": "Linux",
                   "Architecture": "x64",
-                  "downloadLink": "https://functionscdn.azureedge.net/public/2.5.539/Azure.Functions.Cli.linux-x64.2.5.539.zip",
-                  "sha2": "12B8F8C8D5A0906FEFD0D64C7E0B952164B00514629208E6443F2BBD75A39803"
+                  "downloadLink": "https://functionscdn.azureedge.net/public/2.5.553/Azure.Functions.Cli.linux-x64.2.5.553.zip",
+                  "sha2": "766C33F2FD135BE8FC5FA202ADE8EF6FFDD03B3D340CA71926EC9984FF788532"
               },
               {
                   "OS": "MacOS",
                   "Architecture": "x64",
-                  "downloadLink": "https://functionscdn.azureedge.net/public/2.5.539/Azure.Functions.Cli.osx-x64.2.5.539.zip",
-                  "sha2": "C59491C8247103C5E6F74BD0401A3CCA93DCECB5A6887465440279C99CC667F5"
+                  "downloadLink": "https://functionscdn.azureedge.net/public/2.5.553/Azure.Functions.Cli.osx-x64.2.5.553.zip",
+                  "sha2": "DC97A73A3BC2EA83E5448A25FD72BE3D409ACE3B25C3CE6AD7AFD2621A39F8B9"
               },
               {
                   "OS": "Windows",
                   "Architecture": "x64",
-                  "downloadLink": "https://functionscdn.azureedge.net/public/2.5.539/Azure.Functions.Cli.win-x64.2.5.539.zip",
-                  "sha2": "4F5AB7147DC79055F885F8A6AA93861B59754F2BADD466B16D278160376F0564"
+                  "downloadLink": "https://functionscdn.azureedge.net/public/2.5.553/Azure.Functions.Cli.win-x64.2.5.553.zip",
+                  "sha2": "3C25303C26D3282683B3CAE841B405318FB7B348323CD7875871B80252D8BFA9"
               },
               {
                   "OS": "Windows",
                   "Architecture": "x86",
-                  "downloadLink": "https://functionscdn.azureedge.net/public/2.5.539/Azure.Functions.Cli.win-x86.2.5.539.zip",
-                  "sha2": "F4E3D7F90DA5C6990F9160450E6B66CDCF004C691ECA1CA7C9372DD1A810205B"
+                  "downloadLink": "https://functionscdn.azureedge.net/public/2.5.553/Azure.Functions.Cli.win-x86.2.5.553.zip",
+                  "sha2": "DAD1D079D8A901827D5BFF18A53A2B08627831183A541F6D9D0129EB54FE1D61"
               }
           ]
       },


### PR DESCRIPTION
There was a bug is CLI. We are able to skip OGFs run, this PR updates "release".