### PR TITLE
Update v2 release and preview

### DIFF
--- a/cli-feed-v3-2.json
+++ b/cli-feed-v3-2.json
@@ -17,7 +17,7 @@
       "hidden": true
     },
     "v2": {
-      "release": "2.45.1",
+      "release": "2.46.0",
       "displayName": "Azure Functions v2 (.NET Core)",
       "displayVersion": "v2",
       "releaseQuality": "GA",
@@ -33,7 +33,7 @@
       "hidden": true
     },
     "v2-preview": {
-      "release": "2.45.1",
+      "release": "2.46.0",
       "displayName": "Azure Functions v2 Preview (.NET Core)",
       "displayVersion": "v2",
       "releaseQuality": "Preview",

--- a/cli-feed-v3.json
+++ b/cli-feed-v3.json
@@ -17,7 +17,7 @@
       "hidden": true
     },
     "v2": {
-      "release": "2.45.1",
+      "release": "2.46.0",
       "displayName": "Azure Functions v2 (.NET Core)",
       "displayVersion": "v2",
       "releaseQuality": "GA",
@@ -33,7 +33,7 @@
       "hidden": true
     },
     "v2-preview": {
-      "release": "2.45.1",
+      "release": "2.46.0",
       "displayName": "Azure Functions v2 Preview (.NET Core)",
       "displayVersion": "v2",
       "releaseQuality": "Preview",


### PR DESCRIPTION
There's no change between 2.7.2100 and 2.7.2184 - https://github.com/Azure/azure-functions-core-tools/compare/2.7.2100...2.7.2184

This is because the update was in a release pipeline and we need to create new version to notify users.

I am not going through the usual E2E tests suite given there's no delta.