### PR TITLE
Updated prerelease to 1.13.0. Added 1.13.0 entry to reference CLI 1.0.28

### DIFF
--- a/cli-feed-v3.json
+++ b/cli-feed-v3.json
@@ -9,7 +9,7 @@
       "hidden": false
     },
     "v1-prerelease": {
-      "release": "1.12.0",
+      "release": "1.13.0",
       "displayName": "Azure Functions v1 Prerelease (.NET Framework)",
       "displayVersion": "v1",
       "releaseQuality": "Prerelease",
@@ -1685,6 +1685,17 @@
       "projectTemplates": "https://www.nuget.org/api/v2/package/Microsoft.Azure.WebJobs.ProjectTemplates/1.0.3.10324",
       "templateApiZip": "https://functionscdn.azureedge.net/public/TemplatesApi/1.0.3.10182.zip",
       "sha2": "DAAB4A003FCFFB6CBC38E2FFE3E880AE154C28ABD9DA49832760DB3D194E45D4",
+      "FUNCTIONS_EXTENSION_VERSION": "~1"
+    },
+    "1.13.0": {
+      "Microsoft.NET.Sdk.Functions": "1.0.29",
+      "cli": "https://functionscdn.azureedge.net/public/1.0.28/Azure.Functions.Cli.zip",
+      "nodeVersion": "6.5.0",
+      "localEntryPoint": "func.exe",
+      "itemTemplates": "https://www.nuget.org/api/v2/package/Microsoft.Azure.WebJobs.ItemTemplates/1.0.3.10324",
+      "projectTemplates": "https://www.nuget.org/api/v2/package/Microsoft.Azure.WebJobs.ProjectTemplates/1.0.3.10324",
+      "templateApiZip": "https://functionscdn.azureedge.net/public/TemplatesApi/1.0.3.10182.zip",
+      "sha2": "BB4978D83CFBABAE67D4D720FEC1F1171BE0406B2147EF3FECA476C19ADD9920",
       "FUNCTIONS_EXTENSION_VERSION": "~1"
     },
     "2.23.0": {


### PR DESCRIPTION
I changed the `"cli"` cdn url and the `"sha2"` field, everything else was copied from the `1.12.0` entry