### PR TITLE
Release CLI Version 1.0.28

### DIFF
--- a/cli-feed-v3.json
+++ b/cli-feed-v3.json
@@ -1,7 +1,7 @@
 {
   "tags": {
     "v1": {
-      "release": "1.12.0",
+      "release": "1.13.0",
       "displayName": "Azure Functions v1 (.NET Framework)",
       "displayVersion": "v1",
       "releaseQuality": "GA",


### PR DESCRIPTION
Release CLI Version 1.0.28 added in https://github.com/Azure/azure-functions-tooling-feed/pull/216