### PR TITLE
Fix downloading from Core Tools pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ steps:
   inputs:
     packageType: 'sdk'
     version: '2.2.207'
-- task: DownloadBuildArtifacts@0
+- task: DownloadPipelineArtifact@2
   inputs:
     buildType: 'specific'
     project: 'e6a70c92-4128-439f-8012-382fe78d6396'


### PR DESCRIPTION
Using `DownloadBuildArtifacts` fails if the build was re-attempted and didn't succeed the first time. We should use `DownloadPipelineArtifact`