### PR TITLE
Add arm64 entry

### DIFF
--- a/GenerateToolingFeed/Constants.cs
+++ b/GenerateToolingFeed/Constants.cs
@@ -16,7 +16,8 @@ namespace GenerateToolingFeed
         public static readonly Dictionary<string, string> Architecture = new Dictionary<string, string>()
             {
                 { "x64" ,"x64" },
-                { "x86" ,"x86" }
+                { "x86" ,"x86" },
+                { "arm64" ,"arm64" }
             };
 
         public const string FeedAllVersions = "cli-feed-v3.json";

--- a/cli-feed-v4.json
+++ b/cli-feed-v4.json
@@ -5654,6 +5654,14 @@
           "default": "false"
         },
         {
+          "OS": "MacOS",
+          "Architecture": "arm64",
+          "downloadLink": "https://functionscdn.azureedge.net/public/4.0.4385/Azure.Functions.Cli.osx-arm64.4.0.4385.zip",
+          "sha2": "520a79a29fdb5755f431fcaebf270802438d5dcfe6d9d1d220a6ca3688aac0ab",
+          "size": "full",
+          "default": "false"
+        },
+        {
           "OS": "Windows",
           "Architecture": "x64",
           "downloadLink": "https://functionscdn.azureedge.net/public/4.0.4385/Azure.Functions.Cli.min.win-x64.4.0.4385.zip",


### PR DESCRIPTION
To support Apple Silicon macs

I have to add the entry once manually, and going forward it should automatically be included in the generation logic. Including this with the release of https://github.com/Azure/azure-functions-tooling-feed/pull/325