### PR TITLE
Add template prefix for net7-isolated and netfx-isolated

### DIFF
--- a/GenerateToolingFeed/V4Format/V4FormatFeedEntryUpdater.cs
+++ b/GenerateToolingFeed/V4Format/V4FormatFeedEntryUpdater.cs
@@ -8,12 +8,14 @@ namespace GenerateToolingFeed.V4Format
     {
         private static readonly IDictionary<string, string> _dotnetToTemplatesPrefix = new Dictionary<string, string>()
         {
+            { "net7-isolated", "Microsoft.Azure.Functions.Worker" },
             { "net6-isolated", "Microsoft.Azure.Functions.Worker" },
             { "net6", "Microsoft.Azure.WebJobs" },
             { "net5-isolated", "Microsoft.Azure.Functions.Worker" },
             { "netcore3", "Microsoft.Azure.WebJobs" },
             { "netcore2", "Microsoft.Azure.WebJobs" },
-            { "netframework", "Microsoft.Azure.WebJobs" }
+            { "netframework", "Microsoft.Azure.WebJobs" },
+            { "netfx-isolated", "Microsoft.Azure.Functions.Worker" }
         };
 
         public JObject GetUpdatedFeedEntry(JObject feed, CoreToolsInfo coreToolsInfo)


### PR DESCRIPTION
Allows the feed to generate new entries for Core Tools V4, which includes support for the .NET 7 and .NET Framework 4.8.