### PR TITLE
Hide .NET Core 3.1 entry

### DIFF
--- a/cli-feed-v4.json
+++ b/cli-feed-v4.json
@@ -6632,7 +6632,7 @@
           "netcore3": {
             "displayInfo": {
               "displayName": ".NET Core 3.1",
-              "hidden": true,
+              "hidden": false,
               "displayVersion": "v3",
               "targetFramework": ".NET Core",
               "description": "LTS"
@@ -7338,7 +7338,7 @@
           "netcore3": {
             "displayInfo": {
               "displayName": ".NET Core 3.1",
-              "hidden": true,
+              "hidden": false,
               "displayVersion": "v3",
               "targetFramework": ".NET Core",
               "description": "LTS"
@@ -7835,7 +7835,7 @@
           "netcore3": {
             "displayInfo": {
               "displayName": ".NET Core 3.1",
-              "hidden": true,
+              "hidden": false,
               "displayVersion": "v3",
               "targetFramework": ".NET Core",
               "description": "LTS"
@@ -8397,7 +8397,7 @@
           "netcore3": {
             "displayInfo": {
               "displayName": ".NET Core 3.1",
-              "hidden": true,
+              "hidden": false,
               "displayVersion": "v3",
               "targetFramework": ".NET Core",
               "description": "LTS"
@@ -8736,7 +8736,7 @@
           "netcore3": {
             "displayInfo": {
               "displayName": ".NET Core 3.1",
-              "hidden": true,
+              "hidden": false,
               "displayVersion": "v3",
               "targetFramework": ".NET Core",
               "description": "LTS"
@@ -8852,7 +8852,7 @@
           "netcore3": {
             "displayInfo": {
               "displayName": ".NET Core 3.1",
-              "hidden": true,
+              "hidden": false,
               "displayVersion": "v3",
               "targetFramework": ".NET Core",
               "description": "LTS"
@@ -9868,7 +9868,7 @@
           "netcore3": {
             "displayInfo": {
               "displayName": ".NET Core 3.1",
-              "hidden": true,
+              "hidden": false,
               "displayVersion": "v3",
               "targetFramework": ".NET Core",
               "description": "LTS"
@@ -10450,7 +10450,7 @@
           "netcore3": {
             "displayInfo": {
               "displayName": ".NET Core 3.1",
-              "hidden": true,
+              "hidden": false,
               "displayVersion": "v3",
               "targetFramework": ".NET Core",
               "description": "LTS"
@@ -10797,7 +10797,7 @@
           "netcore3": {
             "displayInfo": {
               "displayName": ".NET Core 3.1",
-              "hidden": true,
+              "hidden": false,
               "displayVersion": "v3",
               "targetFramework": ".NET Core",
               "description": "LTS"
@@ -11148,7 +11148,7 @@
           "netcore3": {
             "displayInfo": {
               "displayName": ".NET Core 3.1",
-              "hidden": true,
+              "hidden": false,
               "displayVersion": "v3",
               "targetFramework": ".NET Core",
               "description": "LTS"
@@ -11499,7 +11499,7 @@
           "netcore3": {
             "displayInfo": {
               "displayName": ".NET Core 3.1",
-              "hidden": true,
+              "hidden": false,
               "displayVersion": "v3",
               "targetFramework": ".NET Core",
               "description": "LTS"

--- a/cli-feed-v4.json
+++ b/cli-feed-v4.json
@@ -26,17 +26,17 @@
       "hidden": true
     },
     "v3-preview": {
-      "release": "3.47.0",
+      "release": "3.47.1",
       "releaseQuality": "Preview",
       "hidden": true
     },
     "v3-prerelease": {
-      "release": "3.47.0",
+      "release": "3.47.1",
       "releaseQuality": "Prerelease",
       "hidden": true
     },
     "v3": {
-      "release": "3.47.0",
+      "release": "3.47.1",
       "releaseQuality": "GA",
       "hidden": false
     },
@@ -11492,7 +11492,123 @@
         }
       ]
     },
-    "3.47.0": {
+    "3.47.1": {
+      "templates": "https://functionscdn.azureedge.net/public/TemplatesApi/3.1.1648.zip",
+      "workerRuntimes": {
+        "dotnet": {
+          "netcore3": {
+            "displayInfo": {
+              "displayName": ".NET Core 3.1",
+              "hidden": true,
+              "displayVersion": "v3",
+              "targetFramework": ".NET Core",
+              "description": "LTS"
+            },
+            "capabilities": "",
+            "sdk": {
+              "name": "Microsoft.NET.Sdk.Functions",
+              "version": "3.1.1"
+            },
+            "default": true,
+            "localEntryPoint": "func.exe",
+            "targetFramework": "netcoreapp3.1",
+            "itemTemplates": "https://www.nuget.org/api/v2/package/Microsoft.Azure.WebJobs.ItemTemplates/3.1.2185",
+            "projectTemplates": "https://www.nuget.org/api/v2/package/Microsoft.Azure.WebJobs.ProjectTemplates/3.1.2185",
+            "projectTemplateId": {
+              "csharp": "Microsoft.AzureFunctions.ProjectTemplate.CSharp.3.x"
+            },
+            "localContainerBaseImage": "DOCKER|mcr.microsoft.com/azure-functions/dotnet:3.0-appservice",
+            "serviceAppSettings": {
+              "FUNCTIONS_EXTENSION_VERSION": "~3",
+              "FUNCTIONS_WORKER_RUNTIME": "dotnet"
+            },
+            "windowsSiteConfig": {
+              "netFrameworkVersion": "v4.0"
+            },
+            "linuxSiteConfig": {
+              "linuxFxVersion": "DOTNET|3.1"
+            }
+          },
+          "net5-isolated": {
+            "displayInfo": {
+              "displayName": ".NET 5.0",
+              "hidden": true,
+              "displayVersion": "v3",
+              "targetFramework": ".NET 5",
+              "description": "Isolated"
+            },
+            "capabilities": "isolated,net5",
+            "sdk": {
+              "name": "Microsoft.Azure.Functions.Worker.Sdk",
+              "version": "1.0.3"
+            },
+            "default": false,
+            "toolingSuffix": "net5-isolated",
+            "localEntryPoint": "dotnet.exe",
+            "targetFramework": "net5.0",
+            "itemTemplates": "https://www.nuget.org/api/v2/package/Microsoft.Azure.Functions.Worker.ItemTemplates/3.1.2185",
+            "projectTemplates": "https://www.nuget.org/api/v2/package/Microsoft.Azure.Functions.Worker.ProjectTemplates/3.1.2185",
+            "projectTemplateId": {
+              "csharp": "Microsoft.AzureFunctions.ProjectTemplate.CSharp.Isolated.3.x"
+            },
+            "localContainerBaseImage": "DOCKER|mcr.microsoft.com/azure-functions/dotnet-isolated:3.0-dotnet-isolated5.0-appservice",
+            "serviceAppSettings": {
+              "FUNCTIONS_EXTENSION_VERSION": "~3",
+              "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated"
+            },
+            "windowsSiteConfig": {
+              "netFrameworkVersion": "v4.0"
+            },
+            "linuxSiteConfig": {
+              "linuxFxVersion": "DOTNET-ISOLATED|5.0"
+            }
+          }
+        }
+      },
+      "coreTools": [
+        {
+          "OS": "Linux",
+          "Architecture": "x64",
+          "downloadLink": "https://functionscdn.azureedge.net/public/3.0.4899/Azure.Functions.Cli.linux-x64.3.0.4899.zip",
+          "sha2": "8797525788788b141128229f3a9b88d31c4a14255ce04fef3410c1f89d30a7f1",
+          "size": "full",
+          "default": "false"
+        },
+        {
+          "OS": "MacOS",
+          "Architecture": "x64",
+          "downloadLink": "https://functionscdn.azureedge.net/public/3.0.4899/Azure.Functions.Cli.osx-x64.3.0.4899.zip",
+          "sha2": "cf440e81432b3bdff9e196f146c5c3508c1788fbc9a06339f08fec658fe4e68a",
+          "size": "full",
+          "default": "false"
+        },
+        {
+          "OS": "Windows",
+          "Architecture": "x64",
+          "downloadLink": "https://functionscdn.azureedge.net/public/3.0.4899/Azure.Functions.Cli.min.win-x64.3.0.4899.zip",
+          "sha2": "3ed374ea5b4470a9686c8e6461977cd11e61ce1442369cd392f6a12175cb0877",
+          "size": "minified",
+          "default": "false"
+        },
+        {
+          "OS": "Windows",
+          "Architecture": "x86",
+          "downloadLink": "https://functionscdn.azureedge.net/public/3.0.4899/Azure.Functions.Cli.win-x86.3.0.4899.zip",
+          "sha2": "15b7e3e47d9e63e4f86d2391ace3d3500bf591e239705e032ca438113cbfb75b",
+          "size": "full",
+          "default": "false"
+        },
+        {
+          "OS": "Windows",
+          "Architecture": "x86",
+          "downloadLink": "https://functionscdn.azureedge.net/public/3.0.4899/Azure.Functions.Cli.min.win-x86.3.0.4899.zip",
+          "sha2": "b4efc95e5bdbf0161ec8da53258f6c40ba814c5d4a02b80ef08e215f0cce0f26",
+          "size": "minified",
+          "default": "true"
+        }
+      ]
+    },
+	"3.47.0": {
       "templates": "https://functionscdn.azureedge.net/public/TemplatesApi/3.1.1648.zip",
       "workerRuntimes": {
         "dotnet": {

--- a/cli-feed-v4.json
+++ b/cli-feed-v4.json
@@ -6632,7 +6632,7 @@
           "netcore3": {
             "displayInfo": {
               "displayName": ".NET Core 3.1",
-              "hidden": false,
+              "hidden": true,
               "displayVersion": "v3",
               "targetFramework": ".NET Core",
               "description": "LTS"
@@ -7338,7 +7338,7 @@
           "netcore3": {
             "displayInfo": {
               "displayName": ".NET Core 3.1",
-              "hidden": false,
+              "hidden": true,
               "displayVersion": "v3",
               "targetFramework": ".NET Core",
               "description": "LTS"
@@ -7835,7 +7835,7 @@
           "netcore3": {
             "displayInfo": {
               "displayName": ".NET Core 3.1",
-              "hidden": false,
+              "hidden": true,
               "displayVersion": "v3",
               "targetFramework": ".NET Core",
               "description": "LTS"
@@ -8397,7 +8397,7 @@
           "netcore3": {
             "displayInfo": {
               "displayName": ".NET Core 3.1",
-              "hidden": false,
+              "hidden": true,
               "displayVersion": "v3",
               "targetFramework": ".NET Core",
               "description": "LTS"
@@ -8736,7 +8736,7 @@
           "netcore3": {
             "displayInfo": {
               "displayName": ".NET Core 3.1",
-              "hidden": false,
+              "hidden": true,
               "displayVersion": "v3",
               "targetFramework": ".NET Core",
               "description": "LTS"
@@ -8852,7 +8852,7 @@
           "netcore3": {
             "displayInfo": {
               "displayName": ".NET Core 3.1",
-              "hidden": false,
+              "hidden": true,
               "displayVersion": "v3",
               "targetFramework": ".NET Core",
               "description": "LTS"
@@ -9868,7 +9868,7 @@
           "netcore3": {
             "displayInfo": {
               "displayName": ".NET Core 3.1",
-              "hidden": false,
+              "hidden": true,
               "displayVersion": "v3",
               "targetFramework": ".NET Core",
               "description": "LTS"
@@ -10450,7 +10450,7 @@
           "netcore3": {
             "displayInfo": {
               "displayName": ".NET Core 3.1",
-              "hidden": false,
+              "hidden": true,
               "displayVersion": "v3",
               "targetFramework": ".NET Core",
               "description": "LTS"
@@ -10797,7 +10797,7 @@
           "netcore3": {
             "displayInfo": {
               "displayName": ".NET Core 3.1",
-              "hidden": false,
+              "hidden": true,
               "displayVersion": "v3",
               "targetFramework": ".NET Core",
               "description": "LTS"
@@ -11148,7 +11148,7 @@
           "netcore3": {
             "displayInfo": {
               "displayName": ".NET Core 3.1",
-              "hidden": false,
+              "hidden": true,
               "displayVersion": "v3",
               "targetFramework": ".NET Core",
               "description": "LTS"
@@ -11499,7 +11499,7 @@
           "netcore3": {
             "displayInfo": {
               "displayName": ".NET Core 3.1",
-              "hidden": false,
+              "hidden": true,
               "displayVersion": "v3",
               "targetFramework": ".NET Core",
               "description": "LTS"


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-functions-dotnet-worker/issues/1274

We will discuss (later) whether we should consider removing this entry altogether safely.

Created 3.47.1 from 3.47.0 and set hidden true for .NET Core 3.1. The .NET core 3.1 entry is only present in the c4 feed json.