### PR TITLE
Update dotnet-isolated project and item templates

### DIFF
--- a/cli-feed-v4.json
+++ b/cli-feed-v4.json
@@ -22084,8 +22084,8 @@
             "toolingSuffix": "net5-isolated",
             "localEntryPoint": "dotnet.exe",
             "targetFramework": "net5.0",
-            "itemTemplates": "https://azfunc.visualstudio.com/_apis/resources/Containers/29984196/drop?itemPath=drop%2FMicrosoft.Azure.Functions.Worker.ItemTemplates.NetCore.4.0.2941.nupkg",
-            "projectTemplates": "https://azfunc.visualstudio.com/_apis/resources/Containers/29984196/drop?itemPath=drop%2FMicrosoft.Azure.Functions.Worker.ProjectTemplates.4.0.2941.nupkg",
+            "itemTemplates": "https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/1e0b47db-42dd-4931-a098-8cb031234dcc/nuget/v3/flat2/microsoft.azure.functions.worker.itemtemplates.netcore/4.0.2941/microsoft.azure.functions.worker.itemtemplates.netcore.4.0.2941.nupkg",
+            "projectTemplates": "https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/1e0b47db-42dd-4931-a098-8cb031234dcc/nuget/v3/flat2/microsoft.azure.functions.worker.projecttemplates/4.0.2941/microsoft.azure.functions.worker.projecttemplates.4.0.2941.nupkg",
             "projectTemplateId": {
               "csharp": "Microsoft.AzureFunctions.ProjectTemplate.CSharp.Isolated.3.x"
             },
@@ -22119,8 +22119,8 @@
             "toolingSuffix": "net6-isolated",
             "localEntryPoint": "dotnet.exe",
             "targetFramework": "net6.0",
-            "itemTemplates": "https://azfunc.visualstudio.com/_apis/resources/Containers/29984196/drop?itemPath=drop%2FMicrosoft.Azure.Functions.Worker.ItemTemplates.NetCore.4.0.2941.nupkg",
-            "projectTemplates": "https://www.nuget.org/api/v2/package/Microsoft.Azure.Functions.Worker.ProjectTemplates/4.0.2937",
+            "itemTemplates": "https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/1e0b47db-42dd-4931-a098-8cb031234dcc/nuget/v3/flat2/microsoft.azure.functions.worker.itemtemplates.netcore/4.0.2941/microsoft.azure.functions.worker.itemtemplates.netcore.4.0.2941.nupkg",
+            "projectTemplates": "https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/1e0b47db-42dd-4931-a098-8cb031234dcc/nuget/v3/flat2/microsoft.azure.functions.worker.projecttemplates/4.0.2941/microsoft.azure.functions.worker.projecttemplates.4.0.2941.nupkg",
             "projectTemplateId": {
               "csharp": "Microsoft.AzureFunctions.ProjectTemplate.CSharp.Isolated.3.x"
             },
@@ -22155,8 +22155,8 @@
             "toolingSuffix": "net7-isolated",
             "localEntryPoint": "dotnet.exe",
             "targetFramework": "net7.0",
-            "itemTemplates": "https://azfunc.visualstudio.com/_apis/resources/Containers/29984196/drop?itemPath=drop%2FMicrosoft.Azure.Functions.Worker.ItemTemplates.NetCore.4.0.2941.nupkg",
-            "projectTemplates": "https://azfunc.visualstudio.com/_apis/resources/Containers/29984196/drop?itemPath=drop%2FMicrosoft.Azure.Functions.Worker.ProjectTemplates.4.0.2941.nupkg",
+            "itemTemplates": "https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/1e0b47db-42dd-4931-a098-8cb031234dcc/nuget/v3/flat2/microsoft.azure.functions.worker.itemtemplates.netcore/4.0.2941/microsoft.azure.functions.worker.itemtemplates.netcore.4.0.2941.nupkg",
+            "projectTemplates": "https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/1e0b47db-42dd-4931-a098-8cb031234dcc/nuget/v3/flat2/microsoft.azure.functions.worker.projecttemplates/4.0.2941/microsoft.azure.functions.worker.projecttemplates.4.0.2941.nupkg",
             "projectTemplateId": {
               "csharp": "Microsoft.AzureFunctions.ProjectTemplate.CSharp.Isolated.3.x"
             },
@@ -22191,8 +22191,8 @@
             "toolingSuffix": "net8-isolated",
             "localEntryPoint": "dotnet.exe",
             "targetFramework": "net8.0",
-            "itemTemplates": "https://azfunc.visualstudio.com/_apis/resources/Containers/29984196/drop?itemPath=drop%2FMicrosoft.Azure.Functions.Worker.ItemTemplates.NetCore.4.0.2941.nupkg",
-            "projectTemplates": "https://azfunc.visualstudio.com/_apis/resources/Containers/29984196/drop?itemPath=drop%2FMicrosoft.Azure.Functions.Worker.ProjectTemplates.4.0.2941.nupkg",
+            "itemTemplates": "https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/1e0b47db-42dd-4931-a098-8cb031234dcc/nuget/v3/flat2/microsoft.azure.functions.worker.itemtemplates.netcore/4.0.2941/microsoft.azure.functions.worker.itemtemplates.netcore.4.0.2941.nupkg",
+            "projectTemplates": "https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/1e0b47db-42dd-4931-a098-8cb031234dcc/nuget/v3/flat2/microsoft.azure.functions.worker.projecttemplates/4.0.2941/microsoft.azure.functions.worker.projecttemplates.4.0.2941.nupkg",
             "projectTemplateId": {
               "csharp": "Microsoft.AzureFunctions.ProjectTemplate.CSharp.Isolated.3.x"
             },
@@ -22226,8 +22226,8 @@
             "toolingSuffix": "netfx-isolated",
             "localEntryPoint": "dotnet.exe",
             "targetFramework": "net48",
-            "itemTemplates": "https://azfunc.visualstudio.com/_apis/resources/Containers/29984196/drop?itemPath=drop%2FMicrosoft.Azure.Functions.Worker.ItemTemplates.NetFx.4.0.2941.nupkg",
-            "projectTemplates": "https://azfunc.visualstudio.com/_apis/resources/Containers/29984196/drop?itemPath=drop%2FMicrosoft.Azure.Functions.Worker.ProjectTemplates.4.0.2941.nupkg",
+            "itemTemplates": "https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/1e0b47db-42dd-4931-a098-8cb031234dcc/nuget/v3/flat2/microsoft.azure.functions.worker.itemtemplates.netfx/4.0.2941/microsoft.azure.functions.worker.itemtemplates.netfx.4.0.2941.nupkg",
+            "projectTemplates": "https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/1e0b47db-42dd-4931-a098-8cb031234dcc/nuget/v3/flat2/microsoft.azure.functions.worker.projecttemplates/4.0.2941/microsoft.azure.functions.worker.projecttemplates.4.0.2941.nupkg",
             "projectTemplateId": {
               "csharp": "Microsoft.AzureFunctions.ProjectTemplate.CSharp.Isolated.3.x"
             },

--- a/cli-feed-v4.json
+++ b/cli-feed-v4.json
@@ -22084,8 +22084,8 @@
             "toolingSuffix": "net5-isolated",
             "localEntryPoint": "dotnet.exe",
             "targetFramework": "net5.0",
-            "itemTemplates": "https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/1e0b47db-42dd-4931-a098-8cb031234dcc/nuget/v3/flat2/microsoft.azure.functions.worker.itemtemplates.netcore/4.0.2941/microsoft.azure.functions.worker.itemtemplates.netcore.4.0.2941.nupkg",
-            "projectTemplates": "https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/1e0b47db-42dd-4931-a098-8cb031234dcc/nuget/v3/flat2/microsoft.azure.functions.worker.projecttemplates/4.0.2941/microsoft.azure.functions.worker.projecttemplates.4.0.2941.nupkg",
+            "itemTemplates": "https://www.nuget.org/api/v2/package/Microsoft.Azure.Functions.Worker.ItemTemplates.NetCore/4.0.2945",
+            "projectTemplates": "https://www.nuget.org/api/v2/package/Microsoft.Azure.Functions.Worker.ProjectTemplates/4.0.2945",
             "projectTemplateId": {
               "csharp": "Microsoft.AzureFunctions.ProjectTemplate.CSharp.Isolated.3.x"
             },
@@ -22119,8 +22119,8 @@
             "toolingSuffix": "net6-isolated",
             "localEntryPoint": "dotnet.exe",
             "targetFramework": "net6.0",
-            "itemTemplates": "https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/1e0b47db-42dd-4931-a098-8cb031234dcc/nuget/v3/flat2/microsoft.azure.functions.worker.itemtemplates.netcore/4.0.2941/microsoft.azure.functions.worker.itemtemplates.netcore.4.0.2941.nupkg",
-            "projectTemplates": "https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/1e0b47db-42dd-4931-a098-8cb031234dcc/nuget/v3/flat2/microsoft.azure.functions.worker.projecttemplates/4.0.2941/microsoft.azure.functions.worker.projecttemplates.4.0.2941.nupkg",
+            "itemTemplates": "https://www.nuget.org/api/v2/package/Microsoft.Azure.Functions.Worker.ItemTemplates.NetCore/4.0.2945",
+            "projectTemplates": "https://www.nuget.org/api/v2/package/Microsoft.Azure.Functions.Worker.ProjectTemplates/4.0.2945",
             "projectTemplateId": {
               "csharp": "Microsoft.AzureFunctions.ProjectTemplate.CSharp.Isolated.3.x"
             },
@@ -22155,8 +22155,8 @@
             "toolingSuffix": "net7-isolated",
             "localEntryPoint": "dotnet.exe",
             "targetFramework": "net7.0",
-            "itemTemplates": "https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/1e0b47db-42dd-4931-a098-8cb031234dcc/nuget/v3/flat2/microsoft.azure.functions.worker.itemtemplates.netcore/4.0.2941/microsoft.azure.functions.worker.itemtemplates.netcore.4.0.2941.nupkg",
-            "projectTemplates": "https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/1e0b47db-42dd-4931-a098-8cb031234dcc/nuget/v3/flat2/microsoft.azure.functions.worker.projecttemplates/4.0.2941/microsoft.azure.functions.worker.projecttemplates.4.0.2941.nupkg",
+            "itemTemplates": "https://www.nuget.org/api/v2/package/Microsoft.Azure.Functions.Worker.ItemTemplates.NetCore/4.0.2945",
+            "projectTemplates": "https://www.nuget.org/api/v2/package/Microsoft.Azure.Functions.Worker.ProjectTemplates/4.0.2945",
             "projectTemplateId": {
               "csharp": "Microsoft.AzureFunctions.ProjectTemplate.CSharp.Isolated.3.x"
             },
@@ -22191,8 +22191,8 @@
             "toolingSuffix": "net8-isolated",
             "localEntryPoint": "dotnet.exe",
             "targetFramework": "net8.0",
-            "itemTemplates": "https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/1e0b47db-42dd-4931-a098-8cb031234dcc/nuget/v3/flat2/microsoft.azure.functions.worker.itemtemplates.netcore/4.0.2941/microsoft.azure.functions.worker.itemtemplates.netcore.4.0.2941.nupkg",
-            "projectTemplates": "https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/1e0b47db-42dd-4931-a098-8cb031234dcc/nuget/v3/flat2/microsoft.azure.functions.worker.projecttemplates/4.0.2941/microsoft.azure.functions.worker.projecttemplates.4.0.2941.nupkg",
+            "itemTemplates": "https://www.nuget.org/api/v2/package/Microsoft.Azure.Functions.Worker.ItemTemplates.NetCore/4.0.2945",
+            "projectTemplates": "https://www.nuget.org/api/v2/package/Microsoft.Azure.Functions.Worker.ProjectTemplates/4.0.2945",
             "projectTemplateId": {
               "csharp": "Microsoft.AzureFunctions.ProjectTemplate.CSharp.Isolated.3.x"
             },
@@ -22226,8 +22226,8 @@
             "toolingSuffix": "netfx-isolated",
             "localEntryPoint": "dotnet.exe",
             "targetFramework": "net48",
-            "itemTemplates": "https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/1e0b47db-42dd-4931-a098-8cb031234dcc/nuget/v3/flat2/microsoft.azure.functions.worker.itemtemplates.netfx/4.0.2941/microsoft.azure.functions.worker.itemtemplates.netfx.4.0.2941.nupkg",
-            "projectTemplates": "https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/1e0b47db-42dd-4931-a098-8cb031234dcc/nuget/v3/flat2/microsoft.azure.functions.worker.projecttemplates/4.0.2941/microsoft.azure.functions.worker.projecttemplates.4.0.2941.nupkg",
+            "itemTemplates": "https://www.nuget.org/api/v2/package/Microsoft.Azure.Functions.Worker.ItemTemplates.NetFx/4.0.2945",
+            "projectTemplates": "https://www.nuget.org/api/v2/package/Microsoft.Azure.Functions.Worker.ProjectTemplates/4.0.2945",
             "projectTemplateId": {
               "csharp": "Microsoft.AzureFunctions.ProjectTemplate.CSharp.Isolated.3.x"
             },

--- a/cli-feed-v4.json
+++ b/cli-feed-v4.json
@@ -22084,7 +22084,7 @@
             "toolingSuffix": "net5-isolated",
             "localEntryPoint": "dotnet.exe",
             "targetFramework": "net5.0",
-            "itemTemplates": "https://www.nuget.org/api/v2/package/Microsoft.Azure.Functions.Worker.ItemTemplates.NetCore/4.0.2945",
+            "itemTemplates": "https://www.nuget.org/api/v2/package/Microsoft.Azure.Functions.Worker.ItemTemplates/4.0.2937",
             "projectTemplates": "https://www.nuget.org/api/v2/package/Microsoft.Azure.Functions.Worker.ProjectTemplates/4.0.2945",
             "projectTemplateId": {
               "csharp": "Microsoft.AzureFunctions.ProjectTemplate.CSharp.Isolated.3.x"

--- a/cli-feed-v4.json
+++ b/cli-feed-v4.json
@@ -46,7 +46,7 @@
       "hidden": false
     },
     "v4-prerelease": {
-      "release": "4.66.0",
+      "release": "4.67.0",
       "releaseQuality": "Prerelease",
       "hidden": true
     }

--- a/cli-feed-v4.json
+++ b/cli-feed-v4.json
@@ -22027,6 +22027,279 @@
           "default": "false"
         }
       ]
+    },
+    "4.67.0": {
+      "templates": "https://functionscdn.azureedge.net/public/TemplatesApi/3.1.1648.zip",
+      "workerRuntimes": {
+        "dotnet": {
+          "net6": {
+            "displayInfo": {
+              "displayName": ".NET 6.0",
+              "hidden": false,
+              "displayVersion": "v4",
+              "targetFramework": ".NET",
+              "description": "LTS",
+              "endOfLifeDate": "2024-11-12T00:00:00Z"
+            },
+            "capabilities": "net6",
+            "sdk": {
+              "name": "Microsoft.NET.Sdk.Functions",
+              "version": "4.1.1"
+            },
+            "default": true,
+            "localEntryPoint": "func.exe",
+            "targetFramework": "net6.0",
+            "itemTemplates": "https://www.nuget.org/api/v2/package/Microsoft.Azure.WebJobs.ItemTemplates/4.0.2937",
+            "projectTemplates": "https://www.nuget.org/api/v2/package/Microsoft.Azure.WebJobs.ProjectTemplates/4.0.2937",
+            "projectTemplateId": {
+              "csharp": "Microsoft.AzureFunctions.ProjectTemplate.CSharp.3.x"
+            },
+            "localContainerBaseImage": "DOCKER|mcr.microsoft.com/azure-functions/dotnet:4-appservice",
+            "serviceAppSettings": {
+              "FUNCTIONS_EXTENSION_VERSION": "~4",
+              "FUNCTIONS_WORKER_RUNTIME": "dotnet"
+            },
+            "windowsSiteConfig": {
+              "netFrameworkVersion": "v6.0"
+            },
+            "linuxSiteConfig": {
+              "linuxFxVersion": "DOTNET|6.0"
+            }
+          },
+          "net5-isolated": {
+            "displayInfo": {
+              "displayName": ".NET 5.0",
+              "hidden": true,
+              "displayVersion": "v4",
+              "targetFramework": ".NET 5",
+              "description": "Isolated",
+              "endOfLifeDate": "2022-05-10T00:00:00Z"
+            },
+            "capabilities": "isolated,net5,net6",
+            "sdk": {
+              "name": "Microsoft.Azure.Functions.Worker.Sdk",
+              "version": "1.3.0"
+            },
+            "default": false,
+            "toolingSuffix": "net5-isolated",
+            "localEntryPoint": "dotnet.exe",
+            "targetFramework": "net5.0",
+            "itemTemplates": "https://azfunc.visualstudio.com/_apis/resources/Containers/29984196/drop?itemPath=drop%2FMicrosoft.Azure.Functions.Worker.ItemTemplates.NetCore.4.0.2941.nupkg",
+            "projectTemplates": "https://azfunc.visualstudio.com/_apis/resources/Containers/29984196/drop?itemPath=drop%2FMicrosoft.Azure.Functions.Worker.ProjectTemplates.4.0.2941.nupkg",
+            "projectTemplateId": {
+              "csharp": "Microsoft.AzureFunctions.ProjectTemplate.CSharp.Isolated.3.x"
+            },
+            "localContainerBaseImage": "DOCKER|mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated5.0-appservice",
+            "serviceAppSettings": {
+              "FUNCTIONS_EXTENSION_VERSION": "~4",
+              "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated"
+            },
+            "windowsSiteConfig": {
+              "netFrameworkVersion": "v4.0"
+            },
+            "linuxSiteConfig": {
+              "linuxFxVersion": "DOTNET-ISOLATED|5.0"
+            }
+          },
+          "net6-isolated": {
+            "displayInfo": {
+              "displayName": ".NET 6.0",
+              "hidden": false,
+              "displayVersion": "v4",
+              "targetFramework": ".NET 6",
+              "description": "Isolated LTS",
+              "endOfLifeDate": "2024-11-12T00:00:00Z"
+            },
+            "capabilities": "isolated,net6",
+            "sdk": {
+              "name": "Microsoft.Azure.Functions.Worker.Sdk",
+              "version": "1.3.0"
+            },
+            "default": false,
+            "toolingSuffix": "net6-isolated",
+            "localEntryPoint": "dotnet.exe",
+            "targetFramework": "net6.0",
+            "itemTemplates": "https://azfunc.visualstudio.com/_apis/resources/Containers/29984196/drop?itemPath=drop%2FMicrosoft.Azure.Functions.Worker.ItemTemplates.NetCore.4.0.2941.nupkg",
+            "projectTemplates": "https://www.nuget.org/api/v2/package/Microsoft.Azure.Functions.Worker.ProjectTemplates/4.0.2937",
+            "projectTemplateId": {
+              "csharp": "Microsoft.AzureFunctions.ProjectTemplate.CSharp.Isolated.3.x"
+            },
+            "localContainerBaseImage": "DOCKER|mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated6.0-appservice",
+            "serviceAppSettings": {
+              "FUNCTIONS_EXTENSION_VERSION": "~4",
+              "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
+              "WEBSITE_USE_PLACEHOLDER_DOTNETISOLATED": "1"
+            },
+            "windowsSiteConfig": {
+              "netFrameworkVersion": "v6.0"
+            },
+            "linuxSiteConfig": {
+              "linuxFxVersion": "DOTNET-ISOLATED|6.0"
+            }
+          },
+          "net7-isolated": {
+            "displayInfo": {
+              "displayName": ".NET 7.0",
+              "hidden": false,
+              "displayVersion": "v4",
+              "targetFramework": ".NET 7",
+              "description": "Isolated",
+              "endOfLifeDate": "2024-05-10T00:00:00Z"
+            },
+            "capabilities": "isolated,net6,net7",
+            "sdk": {
+              "name": "Microsoft.Azure.Functions.Worker.Sdk",
+              "version": "1.16.2"
+            },
+            "default": false,
+            "toolingSuffix": "net7-isolated",
+            "localEntryPoint": "dotnet.exe",
+            "targetFramework": "net7.0",
+            "itemTemplates": "https://azfunc.visualstudio.com/_apis/resources/Containers/29984196/drop?itemPath=drop%2FMicrosoft.Azure.Functions.Worker.ItemTemplates.NetCore.4.0.2941.nupkg",
+            "projectTemplates": "https://azfunc.visualstudio.com/_apis/resources/Containers/29984196/drop?itemPath=drop%2FMicrosoft.Azure.Functions.Worker.ProjectTemplates.4.0.2941.nupkg",
+            "projectTemplateId": {
+              "csharp": "Microsoft.AzureFunctions.ProjectTemplate.CSharp.Isolated.3.x"
+            },
+            "localContainerBaseImage": "DOCKER|mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated7.0-appservice",
+            "serviceAppSettings": {
+              "FUNCTIONS_EXTENSION_VERSION": "~4",
+              "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
+              "WEBSITE_USE_PLACEHOLDER_DOTNETISOLATED": "1"
+            },
+            "windowsSiteConfig": {
+              "netFrameworkVersion": "v7.0"
+            },
+            "linuxSiteConfig": {
+              "linuxFxVersion": "DOTNET-ISOLATED|7.0"
+            }
+          },
+          "net8-isolated": {
+            "displayInfo": {
+              "displayName": ".NET 8.0",
+              "hidden": false,
+              "displayVersion": "v4",
+              "targetFramework": ".NET 8",
+              "description": "Isolated LTS",
+              "endOfLifeDate": "2026-11-12T00:00:00Z"
+            },
+            "capabilities": "isolated,net6,net7,net8",
+            "sdk": {
+              "name": "Microsoft.Azure.Functions.Worker.Sdk",
+              "version": "1.16.2"
+            },
+            "default": false,
+            "toolingSuffix": "net8-isolated",
+            "localEntryPoint": "dotnet.exe",
+            "targetFramework": "net8.0",
+            "itemTemplates": "https://azfunc.visualstudio.com/_apis/resources/Containers/29984196/drop?itemPath=drop%2FMicrosoft.Azure.Functions.Worker.ItemTemplates.NetCore.4.0.2941.nupkg",
+            "projectTemplates": "https://azfunc.visualstudio.com/_apis/resources/Containers/29984196/drop?itemPath=drop%2FMicrosoft.Azure.Functions.Worker.ProjectTemplates.4.0.2941.nupkg",
+            "projectTemplateId": {
+              "csharp": "Microsoft.AzureFunctions.ProjectTemplate.CSharp.Isolated.3.x"
+            },
+            "localContainerBaseImage": "DOCKER|mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0-appservice",
+            "serviceAppSettings": {
+              "FUNCTIONS_EXTENSION_VERSION": "~4",
+              "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
+              "WEBSITE_USE_PLACEHOLDER_DOTNETISOLATED": "1"
+            },
+            "windowsSiteConfig": {
+              "netFrameworkVersion": "v8.0"
+            },
+            "linuxSiteConfig": {
+              "linuxFxVersion": "DOTNET-ISOLATED|8.0"
+            }
+          },
+          "netfx-isolated": {
+            "displayInfo": {
+              "displayName": ".NET Framework",
+              "hidden": false,
+              "displayVersion": "v4",
+              "targetFramework": ".NET Framework",
+              "description": "Isolated"
+            },
+            "capabilities": "isolated,net6,netfxisolated",
+            "sdk": {
+              "name": "Microsoft.Azure.Functions.Worker.Sdk",
+              "version": "1.16.2"
+            },
+            "default": false,
+            "toolingSuffix": "netfx-isolated",
+            "localEntryPoint": "dotnet.exe",
+            "targetFramework": "net48",
+            "itemTemplates": "https://azfunc.visualstudio.com/_apis/resources/Containers/29984196/drop?itemPath=drop%2FMicrosoft.Azure.Functions.Worker.ItemTemplates.NetFx.4.0.2941.nupkg",
+            "projectTemplates": "https://azfunc.visualstudio.com/_apis/resources/Containers/29984196/drop?itemPath=drop%2FMicrosoft.Azure.Functions.Worker.ProjectTemplates.4.0.2941.nupkg",
+            "projectTemplateId": {
+              "csharp": "Microsoft.AzureFunctions.ProjectTemplate.CSharp.Isolated.3.x"
+            },
+            "localContainerBaseImage": "",
+            "serviceAppSettings": {
+              "FUNCTIONS_EXTENSION_VERSION": "~4",
+              "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated"
+            },
+            "windowsSiteConfig": {
+              "netFrameworkVersion": "v6.0"
+            }
+          }
+        }
+      },
+      "coreTools": [
+        {
+          "OS": "Linux",
+          "Architecture": "x64",
+          "downloadLink": "https://functionscdn.azureedge.net/public/4.0.5504/Azure.Functions.Cli.linux-x64.4.0.5504.zip",
+          "sha2": "a96fd30d6b7c4a04678ee20492e52ceff0a44c382aeac1a8dab0d0f61a42ebd7",
+          "size": "full",
+          "default": "false"
+        },
+        {
+          "OS": "MacOS",
+          "Architecture": "x64",
+          "downloadLink": "https://functionscdn.azureedge.net/public/4.0.5504/Azure.Functions.Cli.osx-x64.4.0.5504.zip",
+          "sha2": "60100907337cc8f2e46fd488655b0436ee6c5e04ce038cd6534ccebb00149d07",
+          "size": "full",
+          "default": "false"
+        },
+        {
+          "OS": "MacOS",
+          "Architecture": "arm64",
+          "downloadLink": "https://functionscdn.azureedge.net/public/4.0.5504/Azure.Functions.Cli.osx-arm64.4.0.5504.zip",
+          "sha2": "24a5c153cdc79402ba55a1e595947b7490d1d618d306d967f4583431d5729557",
+          "size": "full",
+          "default": "false"
+        },
+        {
+          "OS": "Windows",
+          "Architecture": "x64",
+          "downloadLink": "https://functionscdn.azureedge.net/public/4.0.5504/Azure.Functions.Cli.min.win-x64.4.0.5504.zip",
+          "sha2": "0598cf77dd1fa11e2bcfaca695d9a941decf3b2106425d8660697b962981f4d8",
+          "size": "minified",
+          "default": "false"
+        },
+        {
+          "OS": "Windows",
+          "Architecture": "x86",
+          "downloadLink": "https://functionscdn.azureedge.net/public/4.0.5504/Azure.Functions.Cli.win-x86.4.0.5504.zip",
+          "sha2": "9daf028ddee2806fe22fbd95690d285e4eeb913be4c783dffa47c2c2ed909323",
+          "size": "full",
+          "default": "false"
+        },
+        {
+          "OS": "Windows",
+          "Architecture": "x86",
+          "downloadLink": "https://functionscdn.azureedge.net/public/4.0.5504/Azure.Functions.Cli.min.win-x86.4.0.5504.zip",
+          "sha2": "c8cc60f152dea5c79fc0ab5aab16627de99470e82743944ac61e563d25fd995f",
+          "size": "minified",
+          "default": "true"
+        },
+        {
+          "OS": "Windows",
+          "Architecture": "arm64",
+          "downloadLink": "https://functionscdn.azureedge.net/public/4.0.5504/Azure.Functions.Cli.min.win-arm64.4.0.5504.zip",
+          "sha2": "b72d52275b8cd0ddea8436c320583a212cc3664ab20ba8c3460477dd13071990",
+          "size": "minified",
+          "default": "false"
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
Update includes changes from [this templates PR](https://github.com/Azure/azure-functions-templates/pull/1495) which introduces two new templates packages, one for NetFx and one for NetCore apps.

EDIT: @mattchenderson validated that this is picked up correctly by VS by pointing to this feed PR locally. 

Diff of 4.66.0 and 4.67.0: https://gist.github.com/satvu/47d75bfe4569f0623f7a4345e9a1fe59/revisions
