### PR TITLE
Updating the feed generator to use the new CDN domain

### DIFF
--- a/GenerateToolingFeed/V3Format/V3FormatFeedEntryUpdater.cs
+++ b/GenerateToolingFeed/V3Format/V3FormatFeedEntryUpdater.cs
@@ -65,7 +65,7 @@ namespace GenerateToolingFeed.V3Format
             string rid = isMinified ? "min." : string.Empty;
 
             rid += Helper.GetRuntimeIdentifier(false, os, architecture);
-            var url = $"https://functionscdn.azureedge.net/public/{cliVersion}/Azure.Functions.Cli.{rid}{linkSuffix}.{cliVersion}.zip";
+            var url = $"https://cdn.functions.azure.com/public/{cliVersion}/Azure.Functions.Cli.{rid}{linkSuffix}.{cliVersion}.zip";
 
             string bypassDownloadLinkValidation = Environment.GetEnvironmentVariable("bypassDownloadLinkValidation");
             if (bypassDownloadLinkValidation != "1" && !Helper.IsValidDownloadLink(url))

--- a/GenerateToolingFeed/V4Format/V4FormatFeedEntryUpdater.cs
+++ b/GenerateToolingFeed/V4Format/V4FormatFeedEntryUpdater.cs
@@ -109,7 +109,7 @@ namespace GenerateToolingFeed.V4Format
             rid += Helper.GetRuntimeIdentifier(false, os, architecture);
 
             string containerName = $"{coreToolsInfo.MajorVersion}.0.{coreToolsInfo.BuildId}";
-            var url = $"https://functionscdn.azureedge.net/public/{containerName}/Azure.Functions.Cli.{rid}{linkSuffix}.{version}.zip";
+            var url = $"https://cdn.functions.azure.com/public/{containerName}/Azure.Functions.Cli.{rid}{linkSuffix}.{version}.zip";
 
             string bypassDownloadLinkValidation = Environment.GetEnvironmentVariable("bypassDownloadLinkValidation");
             if (bypassDownloadLinkValidation != "1" && !Helper.IsValidDownloadLink(url))


### PR DESCRIPTION
This is the PR to update the feed generator to use the updated CDN domain. Another with update the to tooling feed will follow.
resolves #603