### PR TITLE
Updating generator to skip template updates for out-of-support versions

### DIFF
--- a/GenerateToolingFeed/V4Format/V4FormatFeedEntryUpdater.cs
+++ b/GenerateToolingFeed/V4Format/V4FormatFeedEntryUpdater.cs
@@ -12,7 +12,10 @@ namespace GenerateToolingFeed.V4Format
     {
         private readonly string _tag;
 
-        private readonly IDictionary<string, string> _dotnetToItemTemplates = new Dictionary<string, string>()
+        private const string _itemTemplatesKey = "itemTemplates";
+        private const string _projectTemplatesKey = "projectTemplates";
+
+        private static readonly IDictionary<string, string> _dotnetToItemTemplates = new Dictionary<string, string>()
         {
             { "net10-isolated", "Microsoft.Azure.Functions.Worker.ItemTemplates.NetCore" },
             { "net9-isolated", "Microsoft.Azure.Functions.Worker.ItemTemplates.NetCore" },
@@ -28,7 +31,7 @@ namespace GenerateToolingFeed.V4Format
             { "netfx-isolated", "Microsoft.Azure.Functions.Worker.ItemTemplates.NetFx" }
         };
 
-        private readonly IDictionary<string, string> _dotnetToProjectTemplates = new Dictionary<string, string>()
+        private static readonly IDictionary<string, string> _dotnetToProjectTemplates = new Dictionary<string, string>()
         {
             { "net10-isolated", "Microsoft.Azure.Functions.Worker.ProjectTemplates" },
             { "net9-isolated", "Microsoft.Azure.Functions.Worker.ProjectTemplates" },
@@ -43,6 +46,16 @@ namespace GenerateToolingFeed.V4Format
             { "netframework", "Microsoft.Azure.WebJobs.ProjectTemplates" },
             { "netfx-isolated", "Microsoft.Azure.Functions.Worker.ProjectTemplates" }
         };
+
+        private static IDictionary<string, string> GetEntryToPackageIdMap(string templateType)
+        {
+            return templateType switch
+            {
+                _itemTemplatesKey => _dotnetToItemTemplates,
+                _projectTemplatesKey => _dotnetToProjectTemplates,
+                _ => throw new ArgumentException($"Unknown template type: {templateType}", nameof(templateType))
+            };
+        }
 
         private static readonly IDictionary<string, string> _linkSuffix = new Dictionary<string, string>()
         {
@@ -142,21 +155,63 @@ namespace GenerateToolingFeed.V4Format
 
                 V4FormatDotnetEntry dotnetEntry = dotnetEntryToken?.ToObject<V4FormatDotnetEntry>() ?? throw new Exception($"Cannot parse 'dotnet' object in the feed with label '{dotnetEntryLabel}'");
 
-                if (!_dotnetToItemTemplates.TryGetValue(dotnetEntryLabel, out string itemTemplates))
-                {
-                    throw new Exception($"Cannot find the template package: Unidentified dotnet label '{dotnetEntryLabel}'.");
-                }
+                string currentItemTemplatesPackage = dotnetEntryToken[_itemTemplatesKey]?.ToString() ?? "<none>";
+                string currentProjectTemplatesPackage = dotnetEntryToken[_projectTemplatesKey]?.ToString() ?? "<none>";
 
-                dotnetEntry.itemTemplates = Helper.GetTemplateUrl($"{itemTemplates}", coreToolsMajor);
-
-                if (!_dotnetToProjectTemplates.TryGetValue(dotnetEntryLabel, out string projecTemplate))
+                // If the entry has reached the end of life date, do not advance templates.
+                if (isEntryEol(dotnetEntryToken))
                 {
-                    throw new Exception($"Cannot find the template package: Unidentified dotnet label '{dotnetEntryLabel}'.");
+                    Console.WriteLine($"WARNING: Skipping template update for '{dotnetEntryLabel}' (EOL). Retaining {_itemTemplatesKey}='{currentItemTemplatesPackage}', {_projectTemplatesKey}='{currentProjectTemplatesPackage}'.");
+                    dotnetEntry.itemTemplates = currentItemTemplatesPackage;
+                    dotnetEntry.projectTemplates = currentProjectTemplatesPackage;
                 }
-                dotnetEntry.projectTemplates = Helper.GetTemplateUrl($"{projecTemplate}", coreToolsMajor);
+                else // If the entry is still supported, update the templates.
+                {
+                    dotnetEntry.itemTemplates = GetUpdatedTemplatePackage(dotnetEntryLabel, _itemTemplatesKey, currentItemTemplatesPackage, coreToolsMajor);
+                    dotnetEntry.projectTemplates = GetUpdatedTemplatePackage(dotnetEntryLabel, _projectTemplatesKey, currentProjectTemplatesPackage, coreToolsMajor);
+                }
 
                 Helper.MergeObjectToJToken(dotnetEntryToken, dotnetEntry);
             }
         }
+
+        private static bool isEntryEol(JObject dotnetEntryToken)
+        {
+            var displayInfo = dotnetEntryToken["displayInfo"] as JObject;
+            if (displayInfo == null) return false; // No displayInfo -> treat as active
+
+            string eolDateStr = displayInfo["endOfLifeDate"]?.ToString();
+            if (string.IsNullOrWhiteSpace(eolDateStr)) return false; // Not marked for EOL
+
+            if (DateTime.TryParse(eolDateStr, out DateTime eolDateUtc))
+            {
+                if (DateTime.UtcNow.Date >= eolDateUtc.Date)
+                {
+                    return true; // Past or at EOL date
+                }
+            }
+            return false;
+        }
+
+        private string GetUpdatedTemplatePackage(string dotnetEntryLabel, string templateType, string currentValue, int coreToolsMajor)
+        {
+            var packageIdMap = GetEntryToPackageIdMap(templateType);
+            if (!packageIdMap.TryGetValue(dotnetEntryLabel, out string packageId))
+            {
+                throw new KeyNotFoundException($"Cannot find the {templateType} package ID in map. Unidentified dotnet label '{dotnetEntryLabel}'.");
+            }
+
+            string newValue = Helper.GetTemplateUrl(packageId, coreToolsMajor);
+            bool changed = !string.Equals(currentValue, newValue, StringComparison.OrdinalIgnoreCase);
+            if (changed)
+            {
+                Console.WriteLine($"'{dotnetEntryLabel}' {templateType} update: {currentValue} => {newValue}.");
+            }
+            else
+            {
+                Console.WriteLine($"'{dotnetEntryLabel}' {templateType} already up-to-date.");
+            }
+            return newValue;
+        }
     }
-}
+}

--- a/GenerateToolingFeed/V4Format/V4FormatFeedEntryUpdater.cs
+++ b/GenerateToolingFeed/V4Format/V4FormatFeedEntryUpdater.cs
@@ -12,8 +12,8 @@ namespace GenerateToolingFeed.V4Format
     {
         private readonly string _tag;
 
-        private const string _itemTemplatesKey = "itemTemplates";
-        private const string _projectTemplatesKey = "projectTemplates";
+        private const string ItemTemplatesKey = "itemTemplates";
+        private const string ProjectTemplatesKey = "projectTemplates";
 
         private static readonly IDictionary<string, string> _dotnetToItemTemplates = new Dictionary<string, string>()
         {
@@ -51,8 +51,8 @@ namespace GenerateToolingFeed.V4Format
         {
             return templateType switch
             {
-                _itemTemplatesKey => _dotnetToItemTemplates,
-                _projectTemplatesKey => _dotnetToProjectTemplates,
+                ItemTemplatesKey => _dotnetToItemTemplates,
+                ProjectTemplatesKey => _dotnetToProjectTemplates,
                 _ => throw new ArgumentException($"Unknown template type: {templateType}", nameof(templateType))
             };
         }
@@ -155,20 +155,20 @@ namespace GenerateToolingFeed.V4Format
 
                 V4FormatDotnetEntry dotnetEntry = dotnetEntryToken?.ToObject<V4FormatDotnetEntry>() ?? throw new Exception($"Cannot parse 'dotnet' object in the feed with label '{dotnetEntryLabel}'");
 
-                string currentItemTemplatesPackage = dotnetEntryToken[_itemTemplatesKey]?.ToString() ?? "<none>";
-                string currentProjectTemplatesPackage = dotnetEntryToken[_projectTemplatesKey]?.ToString() ?? "<none>";
+                string currentItemTemplatesPackage = dotnetEntryToken[ItemTemplatesKey]?.ToString() ?? "<none>";
+                string currentProjectTemplatesPackage = dotnetEntryToken[ProjectTemplatesKey]?.ToString() ?? "<none>";
 
                 // If the entry has reached the end of life date, do not advance templates.
                 if (isEntryEol(dotnetEntryToken))
                 {
-                    Console.WriteLine($"WARNING: Skipping template update for '{dotnetEntryLabel}' (EOL). Retaining {_itemTemplatesKey}='{currentItemTemplatesPackage}', {_projectTemplatesKey}='{currentProjectTemplatesPackage}'.");
+                    Console.WriteLine($"WARNING: Skipping template update for '{dotnetEntryLabel}' (EOL). Retaining {ItemTemplatesKey}='{currentItemTemplatesPackage}', {ProjectTemplatesKey}='{currentProjectTemplatesPackage}'.");
                     dotnetEntry.itemTemplates = currentItemTemplatesPackage;
                     dotnetEntry.projectTemplates = currentProjectTemplatesPackage;
                 }
                 else // If the entry is still supported, update the templates.
                 {
-                    dotnetEntry.itemTemplates = GetUpdatedTemplatePackage(dotnetEntryLabel, _itemTemplatesKey, currentItemTemplatesPackage, coreToolsMajor);
-                    dotnetEntry.projectTemplates = GetUpdatedTemplatePackage(dotnetEntryLabel, _projectTemplatesKey, currentProjectTemplatesPackage, coreToolsMajor);
+                    dotnetEntry.itemTemplates = GetUpdatedTemplatePackage(dotnetEntryLabel, ItemTemplatesKey, currentItemTemplatesPackage, coreToolsMajor);
+                    dotnetEntry.projectTemplates = GetUpdatedTemplatePackage(dotnetEntryLabel, ProjectTemplatesKey, currentProjectTemplatesPackage, coreToolsMajor);
                 }
 
                 Helper.MergeObjectToJToken(dotnetEntryToken, dotnetEntry);


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-functions-tooling-feed/issues/623

This PR allows the update process to leave the templates as they were for out-of-support versions. Please note that we are still able to choose to move these versions forward to a newer version if we need to. We are just removing the automation of that.

To support this, there is some minor refactoring. I felt like restructuring the dictionaries was out-of-scope, so I worked around the existing structure with a helper method. But that would be good fodder for future work.

I'm initially opening this PR as a draft because I needed to timebox this initial spike. But here's the general idea. I'll return to it at a later juncture. Edit: the diff is also being calculated strangely, and I suspect that might mean I also end up having to do a rebase once the .NET 10 changes to this file land.