### PR TITLE
Use Azure Artifacts feed

### DIFF
--- a/GenerateToolingFeed/Helper.cs
+++ b/GenerateToolingFeed/Helper.cs
@@ -68,8 +68,17 @@ namespace GenerateToolingFeed
 
         public static string GetLatestPackageVersion(string packageId, int cliMajor)
         {
-            string url = $"https://api.nuget.org/v3-flatcontainer/{packageId.ToLower()}/index.json";
-            var response = HttpClient.GetStringAsync(url).Result;
+            string nugetFlatcontainerBaseUrl = Environment.GetEnvironmentVariable("NUGET_FLATCONTAINER_URL")
+                ?? "https://api.nuget.org/v3-flatcontainer";
+            string url = $"{nugetFlatcontainerBaseUrl}/{packageId.ToLower()}/index.json";
+
+            var request = new HttpRequestMessage(HttpMethod.Get, url);
+            string accessToken = Environment.GetEnvironmentVariable("SYSTEM_ACCESSTOKEN");
+            if (!string.IsNullOrEmpty(accessToken))
+            {
+                request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", accessToken);
+            }
+            var response = HttpClient.SendAsync(request).Result.Content.ReadAsStringAsync().Result;
             var versionsObject = JObject.Parse(response);
 
             var versions = JsonConvert.DeserializeObject<IEnumerable<string>>(versionsObject["versions"].ToString());

--- a/GenerateToolingFeed/Helper.cs
+++ b/GenerateToolingFeed/Helper.cs
@@ -71,6 +71,7 @@ namespace GenerateToolingFeed
             string nugetFlatcontainerBaseUrl = Environment.GetEnvironmentVariable("NUGET_FLATCONTAINER_URL")
                 ?? "https://api.nuget.org/v3-flatcontainer";
             string url = $"{nugetFlatcontainerBaseUrl}/{packageId.ToLower()}/index.json";
+            Console.WriteLine($"[GetLatestPackageVersion] Fetching NuGet versions from: {url}");
 
             var request = new HttpRequestMessage(HttpMethod.Get, url);
             string accessToken = Environment.GetEnvironmentVariable("SYSTEM_ACCESSTOKEN");

--- a/GenerateToolingFeed/Helper.cs
+++ b/GenerateToolingFeed/Helper.cs
@@ -72,13 +72,16 @@ namespace GenerateToolingFeed
                 ?? "https://api.nuget.org/v3-flatcontainer";
             string url = $"{nugetFlatcontainerBaseUrl}/{packageId.ToLower()}/index.json";
 
-            var request = new HttpRequestMessage(HttpMethod.Get, url);
+            using var request = new HttpRequestMessage(HttpMethod.Get, url);
             string accessToken = Environment.GetEnvironmentVariable("SYSTEM_ACCESSTOKEN");
             if (!string.IsNullOrEmpty(accessToken))
             {
                 request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", accessToken);
             }
-            var response = HttpClient.SendAsync(request).Result.Content.ReadAsStringAsync().Result;
+
+            using var responseMessage = HttpClient.SendAsync(request).GetAwaiter().GetResult();
+            responseMessage.EnsureSuccessStatusCode();
+            var response = responseMessage.Content.ReadAsStringAsync().GetAwaiter().GetResult();
             var versionsObject = JObject.Parse(response);
 
             var versions = JsonConvert.DeserializeObject<IEnumerable<string>>(versionsObject["versions"].ToString());

--- a/eng/ci/templates/jobs/build.yml
+++ b/eng/ci/templates/jobs/build.yml
@@ -22,7 +22,7 @@ jobs:
       command: restore
       projects: '$(Build.Repository.LocalPath)/GenerateToolingFeed/*.csproj'
       feedsToUse: select
-      vstsFeed: $(AzureFunctionsStagingFeed)
+      vstsFeed: $(AzureFunctionsArtifactsFeed)
       includeNuGetOrg: false
   - task: DotNetCoreCLI@2
     displayName: Build feed generator tool

--- a/eng/ci/templates/jobs/build.yml
+++ b/eng/ci/templates/jobs/build.yml
@@ -17,10 +17,18 @@ jobs:
       packageType: sdk
       useGlobalJson: true
   - task: DotNetCoreCLI@2
+    displayName: 'Restore packages'
+    inputs:
+      command: restore
+      projects: '$(Build.Repository.LocalPath)/GenerateToolingFeed/*.csproj'
+      feedsToUse: select
+      vstsFeed: $(AzureFunctionsStagingFeed)
+      includeNuGetOrg: false
+  - task: DotNetCoreCLI@2
     displayName: Build feed generator tool
     inputs:
       command: 'publish'
       publishWebProjects: false
       projects: '$(Build.Repository.LocalPath)/GenerateToolingFeed/*.csproj'
-      arguments: '-o $(Build.ArtifactStagingDirectory)'
+      arguments: '--no-restore -o $(Build.ArtifactStagingDirectory)'
       zipAfterPublish: false


### PR DESCRIPTION
**Fix NuGet network isolation violations (SFI-ES4.2.4)**

This PR makes two changes to comply with network isolation policies that block direct access to api.nuget.org.

1. Helper.cs

GetLatestPackageVersion hardcoded a runtime HTTP call to api.nuget.org to look up the latest version of template NuGet packages. This call is made by the compiled exe when generating cli-feed*.json during the release pipeline, and is blocked by the network isolation policy.

The method now points at an Azure Artifacts feed that proxies nuget.org — so the agent never contacts nuget.org directly.

2. build.yml

dotnet publish runs an implicit restore that falls back to nuget.org when no feed is configured. An explicit restore step is added before publish using feedsToUse: select, includeNuGetOrg: false, and a feed name supplied via the $(AzureFunctionsStagingFeed) pipeline variable. The publish step is updated with --no-restore to skip the implicit restore.