### PR TITLE
Onboard tooling feed NuGet restores to CFS

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="upstream-public" value="https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/nuget/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/eng/ci/templates/jobs/build.yml
+++ b/eng/ci/templates/jobs/build.yml
@@ -16,14 +16,15 @@ jobs:
     inputs:
       packageType: sdk
       useGlobalJson: true
+  - task: NuGetAuthenticate@1
+    displayName: Authenticate NuGet feeds
   - task: DotNetCoreCLI@2
     displayName: 'Restore packages'
     inputs:
       command: restore
       projects: '$(Build.Repository.LocalPath)/GenerateToolingFeed/*.csproj'
-      feedsToUse: select
-      vstsFeed: $(AzureFunctionsArtifactsFeed)
-      includeNuGetOrg: false
+      feedsToUse: config
+      nugetConfigPath: '$(Build.Repository.LocalPath)/NuGet.config'
   - task: DotNetCoreCLI@2
     displayName: Build feed generator tool
     inputs:


### PR DESCRIPTION
## Summary
- add a root `NuGet.config` that clears inherited sources and uses only the CFS `upstream-public` NuGet proxy
- authenticate NuGet in the Azure Pipelines build job before restore
- make the explicit restore consume the repository config while preserving `--no-restore` for publish

## Validation
- `dotnet restore .\GenerateToolingFeed\GenerateToolingFeed.csproj --configfile .\NuGet.config --force-evaluate`
- `dotnet build .\GenerateToolingFeed\GenerateToolingFeed.csproj --no-restore`
- restored successfully on Windows with both the project and NuGet config under paths containing spaces
- `.\verifyJson.ps1`

## Audit notes
- NuGet is the only development/build dependency ecosystem in this repository; no npm or Python manifests are present.
- Argument-boundary audit: no shell/process command string was introduced. The CFS URL is a structured XML attribute value, and the interpolated project/config paths are quoted structured `DotNetCoreCLI@2` inputs.
- Existing NuGet package URLs in tooling-feed JSON are customer-facing feed metadata and were intentionally not repointed.